### PR TITLE
Running the clang static analyser turns up an issue with unintialised…

### DIFF
--- a/src/alignment-file.c
+++ b/src/alignment-file.c
@@ -117,16 +117,16 @@ void detect_snps(char filename[])
 
   sequence_names = calloc(DEFAULT_NUM_SAMPLES, sizeof(char*));
 
+  first_sequence = calloc(seq->seq.l + 1, sizeof(char));
+  memset(first_sequence, 'N', length_of_genome);
+
   while ((l = kseq_read(seq)) >= 0) {
     if(number_of_samples == 0)
     {
         length_of_genome = seq->seq.l;
         first_sequence = calloc(length_of_genome + 1, sizeof(char));
 
-        for(i = 0; i < length_of_genome; i++)
-        {
-            first_sequence[i] = 'N';
-        }
+        memset(first_sequence, 'N', length_of_genome);
     }
 
     for(i = 0; i < length_of_genome; i++)


### PR DESCRIPTION
… pointer in alignment-file.c

  - fixed uninitialised memory
  - used faster memset, rather than an initialisation loop.

The clang analyser reports the following, which have now been addressed.  I'm hoping to run some other analysers over the next few days.

$ scan-build gcc -c src/*.c -I .
scan-build: Using '/usr/bin/clang' for static analysis
src/alignment-file.c:126:15: warning: Potential leak of memory pointed to by 'first_sequence'
        for(i = 0; i < length_of_genome; i++)
            ~~^~~
src/alignment-file.c:134:10: warning: Dereference of undefined pointer value
      if(first_sequence[i] == 'N' && !is_unknown(seq->seq.s[i]))
         ^~~~~~~~~~~~~~~~~
src/alignment-file.c:160:10: warning: Dereference of undefined pointer value
      if(first_sequence[i] == '>')
         ^~~~~~~~~~~~~~~~~
src/alignment-file.c:166:3: warning: Function call argument is an uninitialized value
  free(first_sequence);
  ^~~~~~~~~~~~~~~~~~~~
4 warnings generated.
scan-build: 4 bugs found.