### PR TITLE
Ensure C99 compliance

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ PKG_CHECK_MODULES([CHECK],[check >= 0.8.2],[have_check="yes"],
   AC_MSG_WARN(["'Check' unit testing framework not found. It would be impossible to run unit tests!"])
   [have_check="no"])
 
-AC_CHECK_HEADERS([zlib.h math.h])
+AC_CHECK_HEADERS([zlib.h math.h getopt.h])
 AC_CHECK_LIB(m, floor)
 AX_CHECK_ZLIB
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@ snpsitesinclude_HEADERS=alignment-file.h  vcf.h phylib-of-snp-sites.h snp-sites.
 
 bin_PROGRAMS = snp-sites
 snp_sites_SOURCES = main.c
+snp_sites_CFLAGS = --std=c99
 snp_sites_LDADD = libsnp-sites.la -lpthread
 
 # libsnp_sites.so is our library

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <getopt.h>
 #include "snp-sites.h"
 #include "config.h"
 
@@ -91,7 +92,7 @@ int main (int argc, char **argv) {
   {
     print_usage();
   }
-    
+
 	return 0;
 }
 


### PR DESCRIPTION
I've explicitly added C99 to the build settings and fixed the one simple non-compliance issue.

I've also run splint on the code to generate a C99 compliance report.  It returns the list of issues below.  Not all are to do with C99 compliance.  I've looked into each of the issues reported and am happy that, in our case, they're false-positives.  As an example, there's a false-positive where we `gzclose` a file descriptor stating that the memory is not free'd.  The zlib library call and the kseq_destroy call ensure (as much as can be ensured) that memory is free'd.

```text
src/alignment-file.c: (in function ks_init)
src/alignment-file.c:32:262: Arrow access from possibly null pointer ks: ks->f
  A possibly null pointer is dereferenced.  Value is either the result of a
  function which may return null (in which case, code should check it is not
  null), or a global, parameter or structure field declared with the null
  qualifier. (Use -nullderef to inhibit warning)
   src/alignment-file.c:32:216: Storage ks may become null
src/alignment-file.c:32:260: Implicitly only storage ks->f (type gzFile) not
                                released before assignment: ks->f = f
  A memory leak has been detected. Only-qualified storage is not released
  before the last reference to it is lost. (Use -mustfreeonly to inhibit
  warning)
src/alignment-file.c:32:260: Implicitly temp storage f assigned to implicitly
                                only: ks->f = f
  Temp storage (associated with a formal parameter) is transferred to a
  non-temporary reference. The storage may be released or new aliases created.
  (Use -temptrans to inhibit warning)
src/alignment-file.c:32:285: Implicitly only storage ks->buf (type unsigned
    char *) not released before assignment:
    ks->buf = (unsigned char *)malloc(2048)
src/alignment-file.c:32:339: Possibly null storage ks->buf derivable from
                                return value: ks
  Function returns a possibly null pointer, but is not declared using
  /*@null@*/ annotation of result.  If function may return NULL, add /*@null@*/
  annotation to the return value declaration. (Use -nullret to inhibit warning)
   src/alignment-file.c:32:295: Storage ks->buf may become null
src/alignment-file.c:32:339: Returned storage *ks contains 1 undefined field:
                                buf
  Storage derivable from a parameter, return value or global is not defined.
  Use /*@out@*/ to denote passed or returned storage which need not be defined.
  (Use -compdef to inhibit warning)
src/alignment-file.c: (in function ks_destroy)
src/alignment-file.c:32:501: Implicitly temp storage ks passed as only param:
                                free (ks)
src/alignment-file.c: (in function ks_getc)
src/alignment-file.c:32:608: Left operand of && is non-boolean (int):
                                ks->is_eof && ks->begin >= ks->end
  The operand of a boolean operator is not a boolean. Use +ptrnegate to allow !
  to be used on pointers. (Use -boolops to inhibit warning)
src/alignment-file.c: (in function ks_getuntil2)
src/alignment-file.c:32:1062: Test expression for conditional not boolean, type
                                 int: append
  Test expression type is not boolean or int. (Use -predboolint to inhibit
  warning)
src/alignment-file.c:32:1120: Right operand of && is non-boolean (int):
                                 ks->begin >= ks->end && ks->is_eof
src/alignment-file.c:32:1243: Operand of ! is non-boolean (int): !ks->is_eof
src/alignment-file.c:32:1550: Incompatible types for == (unsigned char, char):
                                 ks->buf[i] == '\n'
  To ignore signs in type comparisons use +ignoresigns
src/alignment-file.c:32:1668: Operands of == have incompatible types (unsigned
                                 char, int): ks->buf[i] == delimiter
  To make char and int types equivalent, use +charint.
src/alignment-file.c:32:1944: Incompatible types for != (unsigned char, char):
                                 ks->buf[i] != ' '
src/alignment-file.c:32:2392: Function memcpy expects arg 3 to be size_t gets
                                 int: i - ks->begin
  To allow arbitrary integral types to match any integral type, use
  +matchanyintegral.
src/alignment-file.c:32:2530: Assignment of unsigned char to int:
                                 *dret = ks->buf[i]
src/alignment-file.c:32:2799: Index of possibly null pointer str->s: str->s
   src/alignment-file.c:32:2290: Storage str->s may become null
src/alignment-file.c:32:2841: Return value type size_t does not match declared
                                 type int: str->l
src/alignment-file.c:32:2848: Function returns with possibly null storage
                                 derivable from parameter str->s
  A possibly null pointer is reachable from a parameter or global variable that
  is not declared using a /*@null@*/ annotation. (Use -nullstate to inhibit
  warning)
   src/alignment-file.c:32:2290: Storage str->s may become null
src/alignment-file.c: (in function kseq_init)
src/alignment-file.c:32:3257: Arrow access from possibly null pointer s: s->f
   src/alignment-file.c:32:3214: Storage s may become null
src/alignment-file.c:32:3256: Implicitly only storage s->f (type kstream_t *)
    not released before assignment: s->f = ks_init(fd)
src/alignment-file.c: (in function kseq_destroy)
src/alignment-file.c:32:3541: Implicitly temp storage ks passed as only param:
                                 free (ks)
src/alignment-file.c: (in function kseq_read)
src/alignment-file.c:32:3745: Operands of != have incompatible types (int,
                                 char): c != '>'
  A character constant is used as an int. Use +charintliteral to allow
  character constants to be used as ints.  (This is safe since the actual type
  of a char constant is int.)
src/alignment-file.c:32:3757: Operands of != have incompatible types (int,
                                 char): c != '@'
src/alignment-file.c:32:4019: Passed storage &c not completely defined:
                                 ks_getuntil (..., &c)
src/alignment-file.c:32:4068: Operands of != have incompatible types (int,
                                 char): c != '\n'
src/alignment-file.c:32:4113: Null storage passed as non-null param:
                                 ks_getuntil (..., 0)
  A possibly null pointer is passed as a parameter corresponding to a formal
  parameter with no /*@null@*/ annotation.  If NULL may be used for this
  parameter, add a /*@null@*/ annotation to the function parameter declaration.
  (Use -nullpass to inhibit warning)
src/alignment-file.c:32:4079: Return value (type int) ignored:
                                 ks_getuntil(ks, ...
  Result returned by function call is not used. If this is intended, can cast
  result to (void) to eliminate message. (Use -retvalint to inhibit warning)
src/alignment-file.c:32:4332: Operands of != have incompatible types (int,
                                 char): c != '>'
src/alignment-file.c:32:4344: Operands of != have incompatible types (int,
                                 char): c != '+'
src/alignment-file.c:32:4356: Operands of != have incompatible types (int,
                                 char): c != '@'
src/alignment-file.c:32:4375: Operands of == have incompatible types (int,
                                 char): c == '\n'
src/alignment-file.c:32:4422: Index of possibly null pointer seq->seq.s:
                                 seq->seq.s
   src/alignment-file.c:32:4265: Storage seq->seq.s may become null
src/alignment-file.c:32:4422: Assignment of int to char:
                                 seq->seq.s[seq->seq.l++] = c
src/alignment-file.c:32:4545: Null storage passed as non-null param:
                                 ks_getuntil2 (..., 0, ...)
src/alignment-file.c:32:4514: Return value (type int) ignored:
                                 ks_getuntil2(ks,...
src/alignment-file.c:32:4594: Operands of == have incompatible types (int,
                                 char): c == '>'
src/alignment-file.c:32:4606: Operands of == have incompatible types (int,
                                 char): c == '@'
src/alignment-file.c:32:5099: Index of possibly null pointer seq->seq.s:
                                 seq->seq.s
   src/alignment-file.c:32:4265: Storage seq->seq.s may become null
src/alignment-file.c:32:5099: Assignment of int to char:
                                 seq->seq.s[seq->seq.l] = 0
  Types are incompatible. (Use -type to inhibit warning)
src/alignment-file.c:32:5162: Operands of != have incompatible types (int,
                                 char): c != '+'
src/alignment-file.c:32:5179: Return value type size_t does not match declared
                                 type int: seq->seq.l
src/alignment-file.c:32:5190: Function returns with possibly null storage
                                 derivable from parameter seq->seq.s
   src/alignment-file.c:32:4265: Storage seq->seq.s may become null
src/alignment-file.c:32:5417: Operands of != have incompatible types (int,
                                 char): c != '\n'
src/alignment-file.c:32:5486: Function returns with possibly null storage
                                 derivable from parameter seq->qual.s
   src/alignment-file.c:32:5335: Storage seq->qual.s may become null
src/alignment-file.c:32:5486: Function returns with possibly null storage
                                 derivable from parameter seq->seq.s
   src/alignment-file.c:32:4265: Storage seq->seq.s may become null
src/alignment-file.c:32:5547: Possibly null storage seq->qual.s derivable from
                                 parameter ks_getuntil2 (..., &seq->qual, ...)
   src/alignment-file.c:32:5335: Storage seq->qual.s may become null
src/alignment-file.c:32:5559: Null storage passed as non-null param:
                                 ks_getuntil2 (..., 0, ...)
src/alignment-file.c:32:5712: Function returns with possibly null storage
                                 derivable from parameter seq->qual.s
   src/alignment-file.c:32:5335: Storage seq->qual.s may become null
src/alignment-file.c:32:5712: Function returns with possibly null storage
                                 derivable from parameter seq->seq.s
   src/alignment-file.c:32:4265: Storage seq->seq.s may become null
src/alignment-file.c:32:5772: Return value type size_t does not match declared
                                 type int: seq->seq.l
src/alignment-file.c:32:5783: Function returns with possibly null storage
                                 derivable from parameter seq->qual.s
   src/alignment-file.c:32:5335: Storage seq->qual.s may become null
src/alignment-file.c:32:5783: Function returns with possibly null storage
                                 derivable from parameter seq->seq.s
   src/alignment-file.c:32:4265: Storage seq->seq.s may become null
src/alignment-file.c: (in function get_sequence_names)
src/alignment-file.c:58:12: Unqualified storage sequence_names returned as
                               implicitly only: sequence_names
  Unqualified storage is transferred in an inconsistent way. (Use
  -unqualifiedtrans to inhibit warning)
src/alignment-file.c:58:27: Function returns with global sequence_names
                               referencing released storage
  A global variable does not satisfy its annotations when control is
  transferred. (Use -globstate to inhibit warning)
   src/alignment-file.c:58:12: Storage sequence_names released
src/alignment-file.c: (in function get_snp_locations)
src/alignment-file.c:63:12: Unqualified storage snp_locations returned as
                               implicitly only: snp_locations
src/alignment-file.c:63:26: Function returns with global snp_locations
                               referencing released storage
   src/alignment-file.c:63:12: Storage snp_locations released
src/alignment-file.c: (in function get_bases_for_each_snp)
src/alignment-file.c:93:8: Return value (type int) ignored: fflush(stderr)
src/alignment-file.c:100:3: Return value (type int) ignored: gzclose(fp)
src/alignment-file.c:101:2: Fresh storage fp not released before return
  A memory leak has been detected. Storage allocated locally is not released
  before the last reference to it is lost. (Use -mustfreefresh to inhibit
  warning)
   src/alignment-file.c:76:3: Fresh storage fp created
src/alignment-file.c:101:2: Fresh storage seq not released before return
   src/alignment-file.c:77:3: Fresh storage seq created
```